### PR TITLE
[Bug修复] toInt函数 重命名为 ToInt & 使 ToInt 函数按预期工作

### DIFF
--- a/MusicLyricApp/Bean/MusicLyricsVO.cs
+++ b/MusicLyricApp/Bean/MusicLyricsVO.cs
@@ -473,19 +473,19 @@ namespace MusicLyricApp.Bean
 
                 var split = timestamp.Split(':');
 
-                var minute = GlobalUtils.toInt(split[0], 0);
+                var minute = GlobalUtils.ToInt(split[0], 0);
 
                 int second = 0, millisecond = 0;
                 if (split.Length > 1)
                 {
                     split = split[1].Split('.');
 
-                    second = GlobalUtils.toInt(split[0], 0);
+                    second = GlobalUtils.ToInt(split[0], 0);
 
                     if (split.Length > 1)
                     {
                         // 三位毫秒，右填充 0
-                        millisecond = GlobalUtils.toInt(split[1].PadRight(3, '0'), 0);
+                        millisecond = GlobalUtils.ToInt(split[1].PadRight(3, '0'), 0);
                     }
                 }
 

--- a/MusicLyricApp/Utils/GlobalUtils.cs
+++ b/MusicLyricApp/Utils/GlobalUtils.cs
@@ -347,13 +347,9 @@ namespace MusicLyricApp.Utils
             }
         }
 
-        public static int toInt(string str, int defaultValue)
+        public static int ToInt(string str, int defaultValue)
         {
-            var result = defaultValue;
-
-            int.TryParse(str, out result);
-
-            return result;
+            return int.TryParse(str, out var result) ? result : defaultValue;
         }
 
         public static string MergeStr(IEnumerable<string> strList)


### PR DESCRIPTION
在原来的 `toInt` 实现中:
```c#
public static int toInt(string str, int defaultValue)
{
    var result = defaultValue;

    int.TryParse(str, out result);

    return result;
}
```

无论 `defaultValue` 为什么值, 当解析失败时, `result` 的值都会被覆盖为 0, 虽然在代码中参数 `defaultValue` 全是 0, 但这总归是一个 bug