### PR TITLE
[Fix] Qrc xml parser in QQ Music API GetVerbatimLyric

### DIFF
--- a/MusicLyricApp/Api/Music/QQMusicNativeApi.cs
+++ b/MusicLyricApp/Api/Music/QQMusicNativeApi.cs
@@ -214,6 +214,13 @@ namespace MusicLyricApp.Api.Music
                 var s = "";
                 if (decompressText.Contains("<?xml"))
                 {
+                    // 移除字符串头部的 BOM 标识 (如果有)
+                    string _byteOrderMarkUtf8 = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
+                    if (decompressText.StartsWith(_byteOrderMarkUtf8))
+                    {
+                        decompressText = decompressText.Remove(0, _byteOrderMarkUtf8.Length);
+                    }
+
                     var doc = XmlUtils.Create(decompressText);
 
                     var subDict = new Dictionary<string, XmlNode>();

--- a/MusicLyricApp/Api/Music/QQMusicNativeApi.cs
+++ b/MusicLyricApp/Api/Music/QQMusicNativeApi.cs
@@ -216,7 +216,7 @@ namespace MusicLyricApp.Api.Music
                 {
                     // 移除字符串头部的 BOM 标识 (如果有)
                     string _byteOrderMarkUtf8 = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
-                    if (decompressText.StartsWith(_byteOrderMarkUtf8))
+                    if (decompressText[0] == _byteOrderMarkUtf8[0])
                     {
                         decompressText = decompressText.Remove(0, _byteOrderMarkUtf8.Length);
                     }

--- a/MusicLyricApp/Api/Music/QQMusicNativeApi.cs
+++ b/MusicLyricApp/Api/Music/QQMusicNativeApi.cs
@@ -215,10 +215,10 @@ namespace MusicLyricApp.Api.Music
                 if (decompressText.Contains("<?xml"))
                 {
                     // 移除字符串头部的 BOM 标识 (如果有)
-                    string _byteOrderMarkUtf8 = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
-                    if (decompressText[0] == _byteOrderMarkUtf8[0])
+                    string byteOrderMarkUtf8 = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
+                    if (decompressText[0] == byteOrderMarkUtf8[0])
                     {
-                        decompressText = decompressText.Remove(0, _byteOrderMarkUtf8.Length);
+                        decompressText = decompressText.Remove(0, byteOrderMarkUtf8.Length);
                     }
 
                     var doc = XmlUtils.Create(decompressText);


### PR DESCRIPTION
移除字符串头部的 BOM 标识 (如果有)，以解决部分歌词无法被解析的问题。

因为我在我的一个项目里使用了本项目的代码，故顺带提交 PR 进行修复。
https://github.com/WXRIW/Lyricify-Lyrics-Helper/commit/e6cf00a17dcc4b096c879b28fa020df376bd18e1