### PR TITLE
Add batch song-name search

### DIFF
--- a/cross-platform/MusicLyricApp.Tests/Core/Service/BatchSongMatcherTest.cs
+++ b/cross-platform/MusicLyricApp.Tests/Core/Service/BatchSongMatcherTest.cs
@@ -1,0 +1,157 @@
+using MusicLyricApp.Core.Service;
+using MusicLyricApp.Models;
+
+namespace MusicLyricAppTest.Core.Service;
+
+public class BatchSongMatcherTest
+{
+    [Fact]
+    public void ParseQueries_HandlesPlainLinesAndDeduplicates()
+    {
+        var queries = BatchSongMatcher.ParseQueries("迷星叫\n音一会\n迷星叫\n");
+
+        Assert.Collection(
+            queries,
+            query => Assert.Equal("迷星叫", query.Title),
+            query => Assert.Equal("音一会", query.Title));
+    }
+
+    [Fact]
+    public void ParseQueries_HandlesMarkdownRowsAndSkipsHeader()
+    {
+        const string input = """
+                             | 序号 | 歌曲 | 歌手 |
+                             | ---: | ---- | ---- |
+                             | 1 | 迷星叫 | MyGO!!!!! |
+                             | 2 | ホーミー・タイッ!! | 一家Dumb Rock!（开场嘉宾） |
+                             """;
+
+        var queries = BatchSongMatcher.ParseQueries(input);
+
+        Assert.Equal(2, queries.Count);
+        Assert.Equal(new BatchSongQuery("迷星叫", "MyGO!!!!!"), queries[0]);
+        Assert.Equal(new BatchSongQuery("ホーミー・タイッ!!", "一家Dumb Rock!（开场嘉宾）"), queries[1]);
+    }
+
+    [Fact]
+    public void ParseQueries_HandlesHashHeaderAndNetEaseLinks()
+    {
+        const string input = """
+                             | # | 曲目 | 艺术家 | 网易云直达链接（Top1） | 候选数 |
+                             |---:|---|---|---|---:|
+                             | 1 | 迷星叫 | MyGO!!!!! | https://music.163.com/song?id=2131509441 | 3 |
+                             """;
+
+        var query = Assert.Single(BatchSongMatcher.ParseQueries(input));
+
+        Assert.Equal("迷星叫", query.Title);
+        Assert.Equal("MyGO!!!!!", query.Artist);
+        Assert.Equal("2131509441", query.DirectSongId);
+        Assert.Equal(SearchSourceEnum.NET_EASE_MUSIC, query.DirectSource);
+    }
+
+    [Fact]
+    public void ParseQueries_IgnoresMarkdownProseAroundTable()
+    {
+        const string input = """
+                             # MyGO 9th LIVE DAY2 曲目
+
+                             下面是已经确认的直达链接。
+
+                             | # | 曲目 | 艺术家 | 网易云直达链接（Top1） |
+                             |---:|---|---|---|
+                             | 1 | 音一会 | MyGO!!!!! | https://music.163.com/song?id=2123214058 |
+
+                             来源：现场歌单。
+                             """;
+
+        var query = Assert.Single(BatchSongMatcher.ParseQueries(input));
+
+        Assert.Equal("音一会", query.Title);
+        Assert.Equal("2123214058", query.DirectSongId);
+    }
+
+    [Fact]
+    public void Normalize_IgnoresWidthWhitespaceAndPunctuation()
+    {
+        Assert.Equal(
+            BatchSongMatcher.Normalize("ホーミー・タイッ!!"),
+            BatchSongMatcher.Normalize("ホーミー タイッ！！"));
+    }
+
+    [Fact]
+    public void FindExactCandidates_RejectsFuzzyTitles()
+    {
+        var result = CreateResult(
+            SearchSourceEnum.NET_EASE_MUSIC,
+            ("1", "迷星叫", new[] { "MyGO!!!!!" }),
+            ("2", "迷星叫 - Live", new[] { "MyGO!!!!!" }));
+
+        var candidates = BatchSongMatcher.FindExactCandidates(
+            new BatchSongQuery("迷星叫", null),
+            [result]);
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal("1", candidate.SongId);
+    }
+
+    [Fact]
+    public void RankCandidates_PrefersArtistThenNetEase()
+    {
+        var candidates = new[]
+        {
+            new BatchSongCandidate(SearchSourceEnum.NET_EASE_MUSIC, "1", "迷星叫", ["翻唱歌手"], "A", 1),
+            new BatchSongCandidate(SearchSourceEnum.QQ_MUSIC, "2", "迷星叫", ["MyGO!!!!!"], "B", 1),
+            new BatchSongCandidate(SearchSourceEnum.NET_EASE_MUSIC, "3", "迷星叫", ["MyGO!!!!!"], "C", 1)
+        };
+
+        var ranked = BatchSongMatcher.RankCandidates(candidates, "MyGO!!!!!");
+
+        Assert.Equal(2, ranked.Count);
+        Assert.Equal("3", ranked[0].SongId);
+        Assert.Equal("2", ranked[1].SongId);
+    }
+
+    [Theory]
+    [InlineData("影色舞", "MyGO!!!!!", "影色舞", "MyGO!!!!!", true)]
+    [InlineData("ホーミー・タイッ!!", "一家Dumb Rock!", "ホーミー・タイッ！！", "一家Dumb Rock!", true)]
+    [InlineData("影色舞", "MyGO!!!!!", "影色舞 (instrumental)", "MyGO!!!!!", false)]
+    [InlineData("壱雫空", "MyGO!!!!!", "焚音打", "MyGO!!!!!", false)]
+    [InlineData("歌いましょう鳴らしましょう", "MyGO!!!!!", "夢で逢いましょう", "SARD UNDERGROUND", false)]
+    public void DirectSongMatchesQuery_RejectsWrongSongsAndInstrumentals(
+        string requestedTitle,
+        string requestedArtist,
+        string actualTitle,
+        string actualArtist,
+        bool expected)
+    {
+        var query = new BatchSongQuery(requestedTitle, requestedArtist);
+
+        Assert.Equal(expected, BatchSongMatcher.DirectSongMatchesQuery(query, actualTitle, [actualArtist]));
+    }
+
+    private static SearchResultVo CreateResult(
+        SearchSourceEnum source,
+        params (string id, string title, string[] artists)[] songs)
+    {
+        var result = new SearchResultVo
+        {
+            SearchSource = source,
+            SearchType = SearchTypeEnum.SONG_ID
+        };
+
+        foreach (var song in songs)
+        {
+            result.SongVos.Add(new SearchResultVo.SongSearchResultVo
+            {
+                DisplayId = song.id,
+                Title = song.title,
+                AuthorName = song.artists,
+                AlbumName = "album",
+                Duration = 1
+            });
+        }
+
+        return result;
+    }
+}

--- a/cross-platform/MusicLyricApp.Tests/Core/Service/BatchSongMatcherTest.cs
+++ b/cross-platform/MusicLyricApp.Tests/Core/Service/BatchSongMatcherTest.cs
@@ -16,6 +16,19 @@ public class BatchSongMatcherTest
             query => Assert.Equal("音一会", query.Title));
     }
 
+    [Theory]
+    [InlineData("M5 処救生", "処救生")]
+    [InlineData("M17 羅永線", "羅永線")]
+    [InlineData("EN1 影色舞", "影色舞")]
+    [InlineData("EN2 音一会", "音一会")]
+    [InlineData("m6: 歌いましょう鳴らしましょう", "歌いましょう鳴らしましょう")]
+    public void ParseQueries_StripsLiveSetCuePrefixes(string input, string expectedTitle)
+    {
+        var query = Assert.Single(BatchSongMatcher.ParseQueries(input));
+
+        Assert.Equal(expectedTitle, query.Title);
+    }
+
     [Fact]
     public void ParseQueries_HandlesMarkdownRowsAndSkipsHeader()
     {

--- a/cross-platform/MusicLyricApp/Core/Service/BatchSongMatcher.cs
+++ b/cross-platform/MusicLyricApp/Core/Service/BatchSongMatcher.cs
@@ -23,7 +23,9 @@ public sealed record BatchSongCandidate(
 
 public static class BatchSongMatcher
 {
-    private static readonly Regex ListPrefixRegex = new(@"^\s*(?:[-*+]\s+|\d+[.、)]\s*)", RegexOptions.Compiled);
+    private static readonly Regex ListPrefixRegex = new(
+        @"^\s*(?:[-*+]\s+|\d+[.、)]\s*|(?:M|EN)\s*\d+\s*[:：.、)\-]?\s*)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex MarkdownSeparatorRegex = new(@"^:?-{3,}:?$", RegexOptions.Compiled);
     private static readonly Regex NetEaseSongIdRegex = new(
         @"(?:music\.163\.com/(?:#/)?song\?(?:[^\s|]*&)?id=)(\d+)",

--- a/cross-platform/MusicLyricApp/Core/Service/BatchSongMatcher.cs
+++ b/cross-platform/MusicLyricApp/Core/Service/BatchSongMatcher.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using MusicLyricApp.Models;
+
+namespace MusicLyricApp.Core.Service;
+
+public sealed record BatchSongQuery(
+    string Title,
+    string? Artist,
+    string? DirectSongId = null,
+    SearchSourceEnum? DirectSource = null);
+
+public sealed record BatchSongCandidate(
+    SearchSourceEnum Source,
+    string SongId,
+    string Title,
+    string[] Artists,
+    string Album,
+    long Duration);
+
+public static class BatchSongMatcher
+{
+    private static readonly Regex ListPrefixRegex = new(@"^\s*(?:[-*+]\s+|\d+[.、)]\s*)", RegexOptions.Compiled);
+    private static readonly Regex MarkdownSeparatorRegex = new(@"^:?-{3,}:?$", RegexOptions.Compiled);
+    private static readonly Regex NetEaseSongIdRegex = new(
+        @"(?:music\.163\.com/(?:#/)?song\?(?:[^\s|]*&)?id=)(\d+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public static IReadOnlyList<BatchSongQuery> ParseQueries(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return [];
+        }
+
+        var lines = input.Replace("\r", string.Empty).Split('\n');
+        var containsMarkdownTable = lines.Any(IsMarkdownSeparatorRow);
+        var results = new List<BatchSongQuery>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var rawLine in lines)
+        {
+            if (containsMarkdownTable && !rawLine.Contains('|'))
+            {
+                continue;
+            }
+
+            var parsed = ParseLine(rawLine);
+            if (parsed == null)
+            {
+                continue;
+            }
+
+            var key = $"{Normalize(parsed.Title)}\u001f{Normalize(parsed.Artist)}";
+            if (seen.Add(key))
+            {
+                results.Add(parsed);
+            }
+        }
+
+        return results;
+    }
+
+    public static IReadOnlyList<BatchSongCandidate> FindExactCandidates(
+        BatchSongQuery query,
+        IEnumerable<SearchResultVo> searchResults)
+    {
+        var normalizedTitle = Normalize(query.Title);
+        return searchResults
+            .SelectMany(result => result.SongVos.Select(song => new BatchSongCandidate(
+                result.SearchSource,
+                song.DisplayId,
+                song.Title,
+                song.AuthorName ?? [],
+                song.AlbumName,
+                song.Duration)))
+            .Where(candidate => Normalize(candidate.Title) == normalizedTitle)
+            .GroupBy(candidate => (candidate.Source, candidate.SongId))
+            .Select(group => group.First())
+            .ToList();
+    }
+
+    public static IReadOnlyList<BatchSongCandidate> RankCandidates(
+        IEnumerable<BatchSongCandidate> candidates,
+        string? preferredArtist)
+    {
+        var materialized = candidates.ToList();
+        var matchingArtistExists = materialized.Any(candidate => ArtistMatches(candidate.Artists, preferredArtist));
+        var eligible = matchingArtistExists
+            ? materialized.Where(candidate => ArtistMatches(candidate.Artists, preferredArtist))
+            : materialized;
+
+        return eligible
+            .OrderBy(candidate => candidate.Source == SearchSourceEnum.NET_EASE_MUSIC ? 0 : 1)
+            .ThenBy(candidate => candidate.Title, StringComparer.Ordinal)
+            .ThenBy(candidate => candidate.SongId, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public static bool ArtistMatches(IEnumerable<string> artists, string? preferredArtist)
+    {
+        var normalizedPreferred = Normalize(preferredArtist);
+        if (string.IsNullOrEmpty(normalizedPreferred))
+        {
+            return false;
+        }
+
+        return artists
+            .Select(Normalize)
+            .Where(artist => !string.IsNullOrEmpty(artist))
+            .Any(artist => artist.Contains(normalizedPreferred, StringComparison.Ordinal) ||
+                           normalizedPreferred.Contains(artist, StringComparison.Ordinal));
+    }
+
+    public static bool DirectSongMatchesQuery(
+        BatchSongQuery query,
+        string actualTitle,
+        IEnumerable<string> actualArtists)
+    {
+        if (Normalize(query.Title) != Normalize(actualTitle))
+        {
+            return false;
+        }
+
+        return string.IsNullOrWhiteSpace(query.Artist) || ArtistMatches(actualArtists, query.Artist);
+    }
+
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Normalize(NormalizationForm.FormKC);
+        var builder = new StringBuilder(normalized.Length);
+        foreach (var character in normalized)
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                builder.Append(char.ToLowerInvariant(character));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static BatchSongQuery? ParseLine(string rawLine)
+    {
+        var line = rawLine.Trim();
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return null;
+        }
+
+        if (line.Contains('|'))
+        {
+            var cells = line.Split('|', StringSplitOptions.TrimEntries)
+                .Where(cell => !string.IsNullOrWhiteSpace(cell))
+                .ToList();
+
+            if (cells.Count == 0 || cells.All(cell => MarkdownSeparatorRegex.IsMatch(cell)))
+            {
+                return null;
+            }
+
+            if (IsHeader(cells))
+            {
+                return null;
+            }
+
+            if (cells.Count >= 2 && int.TryParse(cells[0], out _))
+            {
+                return CreateQuery(
+                    cells[1],
+                    cells.Count >= 3 ? cells[2] : null,
+                    cells.Count >= 4 ? cells.Skip(3) : null);
+            }
+
+            if (cells.Count >= 2)
+            {
+                return CreateQuery(
+                    cells[0],
+                    cells[1],
+                    cells.Count >= 3 ? cells.Skip(2) : null);
+            }
+
+            return CreateQuery(cells[0], null);
+        }
+
+        var tabCells = line.Split('\t', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (tabCells.Length >= 2)
+        {
+            return CreateQuery(tabCells[0], tabCells[1]);
+        }
+
+        return CreateQuery(ListPrefixRegex.Replace(line, string.Empty), null);
+    }
+
+    private static bool IsHeader(IReadOnlyList<string> cells)
+    {
+        var first = Normalize(cells[0]);
+        var second = cells.Count > 1 ? Normalize(cells[1]) : string.Empty;
+        return cells[0].Trim() == "#" ||
+               first is "序号" or "编号" or "no" or "number" ||
+               second is "歌曲" or "歌曲名" or "歌名" or "title";
+    }
+
+    private static bool IsMarkdownSeparatorRow(string rawLine)
+    {
+        if (!rawLine.Contains('|'))
+        {
+            return false;
+        }
+
+        var cells = rawLine.Split('|', StringSplitOptions.TrimEntries)
+            .Where(cell => !string.IsNullOrWhiteSpace(cell))
+            .ToList();
+        return cells.Count > 0 && cells.All(cell => MarkdownSeparatorRegex.IsMatch(cell));
+    }
+
+    private static BatchSongQuery? CreateQuery(
+        string? title,
+        string? artist,
+        IEnumerable<string>? extraCells = null)
+    {
+        var cleanTitle = title?.Trim();
+        if (string.IsNullOrWhiteSpace(cleanTitle))
+        {
+            return null;
+        }
+
+        var cleanArtist = string.IsNullOrWhiteSpace(artist) ? null : artist.Trim();
+        var directLinkText = extraCells == null ? string.Empty : string.Join(" ", extraCells);
+        var netEaseMatch = NetEaseSongIdRegex.Match(directLinkText);
+        return netEaseMatch.Success
+            ? new BatchSongQuery(
+                cleanTitle,
+                cleanArtist,
+                netEaseMatch.Groups[1].Value,
+                SearchSourceEnum.NET_EASE_MUSIC)
+            : new BatchSongQuery(cleanTitle, cleanArtist);
+    }
+}

--- a/cross-platform/MusicLyricApp/Core/Service/Music/BaseNativeApi.cs
+++ b/cross-platform/MusicLyricApp/Core/Service/Music/BaseNativeApi.cs
@@ -55,6 +55,23 @@ public abstract class BaseNativeApi(Func<string> cookieFunc)
         return result;
     }
 
+    protected string SendGet(string url)
+    {
+        using var wc = new WebClient();
+        NetworkClientFactory.ConfigureWebClient(wc);
+        var cookie = cookieFunc.Invoke();
+        if (string.IsNullOrWhiteSpace(cookie))
+        {
+            cookie = _defaultCookie;
+        }
+
+        wc.Encoding = Encoding.UTF8;
+        wc.Headers.Add(HttpRequestHeader.Referer, HttpRefer());
+        wc.Headers.Add(HttpRequestHeader.UserAgent, Useragent);
+        wc.Headers.Add(HttpRequestHeader.Cookie, cookie);
+        return wc.DownloadString(url);
+    }
+
     protected string SendJsonPost(string url, Dictionary<string, object> paramDict)
     {
         using (var wc = new WebClient())

--- a/cross-platform/MusicLyricApp/Core/Service/Music/NetEaseMusicNativeApi.cs
+++ b/cross-platform/MusicLyricApp/Core/Service/Music/NetEaseMusicNativeApi.cs
@@ -82,7 +82,11 @@ public class NetEaseMusicNativeApi : BaseNativeApi
 
         if (code == "50000005")
         {
-            return ResultVo<SearchResult>.Failure(ErrorMsgConst.NEED_LOGIN);
+            var fallbackUrl = "https://music.163.com/api/search/get/web" +
+                              $"?s={Uri.EscapeDataString(keyword)}&type={type}&limit=20&offset=0";
+            obj = (JObject)JsonConvert.DeserializeObject(SendGet(fallbackUrl));
+            code = obj?["code"]?.ToString();
+            result = obj?["result"];
         }
 
         if (result == null || code != "200")
@@ -97,7 +101,26 @@ public class NetEaseMusicNativeApi : BaseNativeApi
             resultStr = NetEaseMusicSearchUtils.Decode(resultStr);
         }
 
+        resultStr = NormalizeLegacySearchResult(resultStr);
         return new ResultVo<SearchResult>(JsonConvert.DeserializeObject<SearchResult>(resultStr));
+    }
+
+    private static string NormalizeLegacySearchResult(string resultStr)
+    {
+        var result = JObject.Parse(resultStr);
+        if (result["songs"] is not JArray songs)
+        {
+            return resultStr;
+        }
+
+        foreach (var song in songs.OfType<JObject>())
+        {
+            song["ar"] ??= song["artists"];
+            song["al"] ??= song["album"];
+            song["dt"] ??= song["duration"];
+        }
+
+        return result.ToString(Formatting.None);
     }
 
     /// <summary>

--- a/cross-platform/MusicLyricApp/Core/Service/Music/NetEaseMusicNativeApi.cs
+++ b/cross-platform/MusicLyricApp/Core/Service/Music/NetEaseMusicNativeApi.cs
@@ -108,9 +108,15 @@ public class NetEaseMusicNativeApi : BaseNativeApi
     private static string NormalizeLegacySearchResult(string resultStr)
     {
         var result = JObject.Parse(resultStr);
+        NormalizeLegacySongs(result);
+        return result.ToString(Formatting.None);
+    }
+
+    private static void NormalizeLegacySongs(JObject result)
+    {
         if (result["songs"] is not JArray songs)
         {
-            return resultStr;
+            return;
         }
 
         foreach (var song in songs.OfType<JObject>())
@@ -119,8 +125,6 @@ public class NetEaseMusicNativeApi : BaseNativeApi
             song["al"] ??= song["album"];
             song["dt"] ??= song["duration"];
         }
-
-        return result.ToString(Formatting.None);
     }
 
     /// <summary>
@@ -292,10 +296,11 @@ public class NetEaseMusicNativeApi : BaseNativeApi
     {
         const string url = "https://music.163.com/weapi/v3/song/detail?csrf_token=";
 
+        var requestedIds = inputSongIds.Distinct().ToList();
         var allResults = new List<Song>();
         var cnt = 1;
         
-        foreach (var songIds in GlobalUtils.Batch(inputSongIds, Constants.BatchQuerySize))
+        foreach (var songIds in GlobalUtils.Batch(requestedIds, Constants.BatchQuerySize))
         {
             var songs = songIds.Select(id => new { id });
             var data = new Dictionary<string, string>
@@ -314,6 +319,22 @@ public class NetEaseMusicNativeApi : BaseNativeApi
             if (cnt++ % 2 == 0)
             {
                 Thread.Sleep(Constants.SleepMsBetweenBatchQuery); // sleep 500ms after every two batches
+            }
+        }
+
+        var foundIds = allResults.Select(song => song.Id).ToHashSet();
+        var missingIds = requestedIds.Where(id => !foundIds.Contains(id)).ToList();
+        foreach (var songIds in GlobalUtils.Batch(missingIds, Constants.BatchQuerySize))
+        {
+            var idList = $"[{string.Join(',', songIds)}]";
+            var fallbackUrl = "https://music.163.com/api/song/detail/" +
+                              $"?ids={Uri.EscapeDataString(idList)}";
+            var fallbackObject = JObject.Parse(SendGet(fallbackUrl));
+            NormalizeLegacySongs(fallbackObject);
+            var fallbackResult = fallbackObject.ToObject<DetailResult>();
+            if (fallbackResult?.Code == 200 && fallbackResult.Songs != null)
+            {
+                allResults.AddRange(fallbackResult.Songs.Where(song => foundIds.Add(song.Id)));
             }
         }
         

--- a/cross-platform/MusicLyricApp/NLog.config
+++ b/cross-platform/MusicLyricApp/NLog.config
@@ -4,12 +4,12 @@
       xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
       autoReload="true"
       throwExceptions="false"
-      internalLogLevel="Off" internalLogFile="${basedir}/MusicLyricApp-nlog-internal.log">
+      internalLogLevel="Off" internalLogFile="${specialfolder:folder=LocalApplicationData}/MusicLyricApp/logs/MusicLyricApp-nlog-internal.log">
 
   <targets async="true">
     <target name="file" xsi:type="AsyncWrapper" queueLimit="5000" overflowAction="Discard">
       <target xsi:type="File"
-              fileName="${basedir}/MusicLyricApp-${shortdate}.log"
+              fileName="${specialfolder:folder=LocalApplicationData}/MusicLyricApp/logs/MusicLyricApp-${shortdate}.log"
               encoding="utf-8"
               layout="${longdate} | ${level:uppercase=true:padding=-5} | ${message:exceptionSeparator=\r\n:withException=true}" />
     </target>

--- a/cross-platform/MusicLyricApp/ViewModels/BatchSearchItemViewModel.cs
+++ b/cross-platform/MusicLyricApp/ViewModels/BatchSearchItemViewModel.cs
@@ -6,11 +6,14 @@ namespace MusicLyricApp.ViewModels;
 public partial class BatchSearchItemViewModel : ObservableObject
 {
     [ObservableProperty] private bool _isSelected;
+    [ObservableProperty] private bool _isKeywordResult;
+    [ObservableProperty] private string _requestedName = "";
     [ObservableProperty] private string _songSource = "";
     [ObservableProperty] private string _songId = "";
     [ObservableProperty] private string _songName = "";
     [ObservableProperty] private string _singer = "";
     [ObservableProperty] private string _album = "";
+    [ObservableProperty] private string _translationStatus = "";
     [ObservableProperty] private SearchSourceEnum _sourceEnum;
     [ObservableProperty] private string _status = "";
     [ObservableProperty] private string _error = "";

--- a/cross-platform/MusicLyricApp/ViewModels/BatchSearchViewModel.cs
+++ b/cross-platform/MusicLyricApp/ViewModels/BatchSearchViewModel.cs
@@ -138,7 +138,7 @@ public partial class BatchSearchViewModel : ViewModelBase
             return;
         }
 
-        RemovePreviousKeywordResults();
+        ResetBatchResults();
         IsBatchNameSearching = true;
         var matchedCount = 0;
         var unresolvedCount = 0;
@@ -391,8 +391,15 @@ public partial class BatchSearchViewModel : ViewModelBase
 
         if (candidates.Count == 0)
         {
-            var message = searchAttempt.errors.Count > 0
-                ? string.Join("；", searchAttempt.errors)
+            var messages = new List<string>();
+            if (searchAttempt.results.Any(result => result.SearchSource == SearchSourceEnum.NET_EASE_MUSIC))
+            {
+                messages.Add("网易云：未找到完全同名结果");
+            }
+
+            messages.AddRange(searchAttempt.errors);
+            var message = messages.Count > 0
+                ? string.Join("；", messages)
                 : "网易云与 QQ 音乐均无完全同名结果";
             AddUnresolvedKeyword(query, message);
             return false;
@@ -526,18 +533,12 @@ public partial class BatchSearchViewModel : ViewModelBase
         });
     }
 
-    private void RemovePreviousKeywordResults()
+    private void ResetBatchResults()
     {
-        foreach (var item in Items.Where(item => item.IsKeywordResult).ToList())
-        {
-            if (!string.IsNullOrWhiteSpace(item.SongId))
-            {
-                _saveMap.Remove(item.SongId);
-                _songLinkMap.Remove(item.SongId);
-            }
-
-            Items.Remove(item);
-        }
+        Items.Clear();
+        _saveMap.Clear();
+        _songLinkMap.Clear();
+        RefreshStats();
     }
 
     private static int ScoreFetchedCandidate(

--- a/cross-platform/MusicLyricApp/ViewModels/BatchSearchViewModel.cs
+++ b/cross-platform/MusicLyricApp/ViewModels/BatchSearchViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -27,6 +28,9 @@ public partial class BatchSearchViewModel : ViewModelBase
     public ObservableCollection<BatchSearchItemViewModel> Items { get; } = new();
 
     [ObservableProperty] private string _batchInputText = "";
+    [ObservableProperty] private string _preferredArtist = "MyGO!!!!!";
+    [ObservableProperty] private string _searchProgressText = "";
+    [ObservableProperty] private bool _isBatchNameSearching;
     [ObservableProperty] private string _tipTimestamp = "";
     [ObservableProperty] private string _tipNormalMessage = "";
     [ObservableProperty] private string _tipErrorMessage = "";
@@ -56,7 +60,10 @@ public partial class BatchSearchViewModel : ViewModelBase
             BatchInputText = inputText;
         }
 
-        var existing = Items.ToDictionary(i => i.SongId, i => i);
+        var existing = Items
+            .Where(i => !string.IsNullOrWhiteSpace(i.SongId))
+            .GroupBy(i => i.SongId)
+            .ToDictionary(group => group.Key, group => group.First());
         var added = 0;
 
         foreach (var input in inputSongIds)
@@ -85,6 +92,7 @@ public partial class BatchSearchViewModel : ViewModelBase
                 item.SourceEnum = input.SearchSource;
                 item.Singer = string.Join(_settingBean.Config.SingerSeparator, saveVo.SongVo.Singer);
                 item.Album = saveVo.SongVo.Album;
+                item.TranslationStatus = string.IsNullOrWhiteSpace(saveVo.LyricVo.TranslateLyric) ? "无" : "有";
                 item.Status = "Ready";
                 item.Error = saveVo.LyricVo.IsEmpty() ? ErrorMsgConst.LRC_NOT_EXIST : "";
                 item.Progress = 100;
@@ -107,6 +115,72 @@ public partial class BatchSearchViewModel : ViewModelBase
 
         RefreshStats();
         SetTip($"已同步 {added} 条搜索结果。", false);
+    }
+
+    [RelayCommand]
+    private async Task ExecuteSearchNamesAsync()
+    {
+        if (IsBatchNameSearching)
+        {
+            return;
+        }
+
+        var queries = BatchSongMatcher.ParseQueries(BatchInputText);
+        if (queries.Count == 0)
+        {
+            SetTip("请每行输入一个歌名。", true);
+            return;
+        }
+
+        if (queries.Count > Constants.BatchQuerySize)
+        {
+            SetTip($"单次最多处理 {Constants.BatchQuerySize} 首歌曲。", true);
+            return;
+        }
+
+        RemovePreviousKeywordResults();
+        IsBatchNameSearching = true;
+        var matchedCount = 0;
+        var unresolvedCount = 0;
+
+        try
+        {
+            for (var index = 0; index < queries.Count; index++)
+            {
+                var query = queries[index];
+                SearchProgressText = $"{index + 1}/{queries.Count}  正在搜索：{query.Title}";
+
+                try
+                {
+                    if (await ResolveKeywordAsync(query))
+                    {
+                        matchedCount++;
+                    }
+                    else
+                    {
+                        unresolvedCount++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    AddUnresolvedKeyword(query, ex.Message);
+                    unresolvedCount++;
+                }
+
+                if (index + 1 < queries.Count)
+                {
+                    await Task.Delay(Constants.SleepMsBetweenBatchQuery);
+                }
+            }
+
+            RefreshStats();
+            SetTip($"歌名批量搜索完成：匹配 {matchedCount}，待处理 {unresolvedCount}。", unresolvedCount > 0);
+        }
+        finally
+        {
+            IsBatchNameSearching = false;
+            SearchProgressText = "";
+        }
     }
 
     [RelayCommand]
@@ -243,9 +317,9 @@ public partial class BatchSearchViewModel : ViewModelBase
     private void ExecuteViewDetail(BatchSearchItemViewModel? item)
     {
         var target = item ?? Items.FirstOrDefault(x => x.IsSelected);
-        if (target == null)
+        if (target == null || string.IsNullOrWhiteSpace(target.SongId))
         {
-            SetTip("未选择可查看项。", false);
+            SetTip("未选择已匹配的歌曲。", false);
             return;
         }
 
@@ -274,6 +348,225 @@ public partial class BatchSearchViewModel : ViewModelBase
         {
             SetTip(ex.Message, true);
         }
+    }
+
+    private async Task<bool> ResolveKeywordAsync(BatchSongQuery query)
+    {
+        if (!string.IsNullOrWhiteSpace(query.DirectSongId) && query.DirectSource.HasValue)
+        {
+            return await ResolveDirectSongAsync(query);
+        }
+
+        var searchAttempt = await Task.Run(() =>
+        {
+            var results = new List<SearchResultVo>();
+            var errors = new List<string>();
+            foreach (var source in Enum.GetValues<SearchSourceEnum>())
+            {
+                try
+                {
+                    var response = _searchService.GetMusicApi(source).Search(query.Title, SearchTypeEnum.SONG_ID);
+                    if (response.IsSuccess() && !response.Data.IsEmpty())
+                    {
+                        results.Add(response.Data);
+                    }
+                    else if (!response.IsSuccess())
+                    {
+                        errors.Add($"{source.ToDescription()}：{response.ErrorMsg}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"{source.ToDescription()}：{ex.Message}");
+                }
+            }
+
+            return (results, errors);
+        });
+
+        var preferredArtist = query.Artist ?? PreferredArtist;
+        var candidates = BatchSongMatcher.RankCandidates(
+            BatchSongMatcher.FindExactCandidates(query, searchAttempt.results),
+            preferredArtist);
+
+        if (candidates.Count == 0)
+        {
+            var message = searchAttempt.errors.Count > 0
+                ? string.Join("；", searchAttempt.errors)
+                : "网易云与 QQ 音乐均无完全同名结果";
+            AddUnresolvedKeyword(query, message);
+            return false;
+        }
+
+        var providerCandidates = candidates
+            .GroupBy(candidate => candidate.Source)
+            .Select(group => group.First())
+            .ToList();
+
+        var fetched = new List<(BatchSongCandidate candidate, SaveVo saveVo, int score)>();
+        var errors = new List<string>();
+
+        foreach (var candidate in providerCandidates)
+        {
+            var rawInput = new InputSongId(candidate.SongId, candidate.Source, SearchTypeEnum.SONG_ID);
+            var inputSongId = new InputSongId(candidate.SongId, rawInput);
+            var result = await Task.Run(() => _searchService.SearchSongs([inputSongId], _settingBean));
+
+            if (!result.TryGetValue(candidate.SongId, out var songResult) || !songResult.IsSuccess())
+            {
+                errors.Add(songResult?.ErrorMsg ?? $"{candidate.Source.ToDescription()} 查询失败");
+                continue;
+            }
+
+            var saveVo = songResult.Data;
+            if (saveVo.LyricVo.IsEmpty())
+            {
+                errors.Add($"{candidate.Source.ToDescription()} 无歌词");
+                continue;
+            }
+
+            var score = ScoreFetchedCandidate(candidate, saveVo, preferredArtist);
+            fetched.Add((candidate, saveVo, score));
+        }
+
+        if (fetched.Count == 0)
+        {
+            AddUnresolvedKeyword(query, errors.Count == 0 ? "完全同名结果没有可用歌词" : string.Join("；", errors));
+            return false;
+        }
+
+        var best = fetched
+            .OrderByDescending(item => item.score)
+            .ThenBy(item => item.candidate.Source == SearchSourceEnum.NET_EASE_MUSIC ? 0 : 1)
+            .First();
+
+        AddKeywordResult(query, best.candidate, best.saveVo);
+        return true;
+    }
+
+    private async Task<bool> ResolveDirectSongAsync(BatchSongQuery query)
+    {
+        var source = query.DirectSource!.Value;
+        var rawInput = new InputSongId(query.DirectSongId!, source, SearchTypeEnum.SONG_ID);
+        var inputSongId = new InputSongId(query.DirectSongId!, rawInput);
+        var result = await Task.Run(() => _searchService.SearchSongs([inputSongId], _settingBean));
+
+        if (!result.TryGetValue(query.DirectSongId!, out var songResult) || !songResult.IsSuccess())
+        {
+            AddUnresolvedKeyword(query, songResult?.ErrorMsg ?? $"{source.ToDescription()} 查询失败");
+            return false;
+        }
+
+        var saveVo = songResult.Data;
+        if (saveVo.LyricVo.IsEmpty())
+        {
+            AddUnresolvedKeyword(query, $"{source.ToDescription()} 无歌词");
+            return false;
+        }
+
+        if (!BatchSongMatcher.DirectSongMatchesQuery(query, saveVo.SongVo.Name, saveVo.SongVo.Singer))
+        {
+            var actualArtist = string.Join(_settingBean.Config.SingerSeparator, saveVo.SongVo.Singer);
+            AddUnresolvedKeyword(
+                query,
+                $"直达链接对应“{saveVo.SongVo.Name}” / {actualArtist}，与输入曲目不一致");
+            return false;
+        }
+
+        var candidate = new BatchSongCandidate(
+            source,
+            query.DirectSongId!,
+            saveVo.SongVo.Name,
+            saveVo.SongVo.Singer,
+            saveVo.SongVo.Album,
+            0);
+        AddKeywordResult(query, candidate, saveVo);
+        return true;
+    }
+
+    private void AddKeywordResult(BatchSongQuery query, BatchSongCandidate candidate, SaveVo saveVo)
+    {
+        var item = Items.FirstOrDefault(existing =>
+            existing.SongId == candidate.SongId && existing.SourceEnum == candidate.Source);
+
+        if (item == null)
+        {
+            item = new BatchSearchItemViewModel();
+            Items.Add(item);
+        }
+
+        _saveMap[candidate.SongId] = saveVo;
+        item.IsKeywordResult = true;
+        item.IsSelected = true;
+        item.RequestedName = query.Title;
+        item.SongId = candidate.SongId;
+        item.SongName = saveVo.SongVo.Name;
+        item.SongSource = GetSourceName(candidate.Source);
+        item.SourceEnum = candidate.Source;
+        item.Singer = string.Join(_settingBean.Config.SingerSeparator, saveVo.SongVo.Singer);
+        item.Album = saveVo.SongVo.Album;
+        item.TranslationStatus = string.IsNullOrWhiteSpace(saveVo.LyricVo.TranslateLyric) ? "无" : "有";
+        item.Status = "Ready";
+        item.Error = string.IsNullOrWhiteSpace(saveVo.LyricVo.TranslateLyric) ? "平台未提供译文" : "";
+        item.Progress = 100;
+    }
+
+    private void AddUnresolvedKeyword(BatchSongQuery query, string error)
+    {
+        Items.Add(new BatchSearchItemViewModel
+        {
+            IsKeywordResult = true,
+            IsSelected = false,
+            RequestedName = query.Title,
+            Singer = query.Artist ?? PreferredArtist,
+            TranslationStatus = "-",
+            Status = "Unresolved",
+            Error = error,
+            Progress = 0
+        });
+    }
+
+    private void RemovePreviousKeywordResults()
+    {
+        foreach (var item in Items.Where(item => item.IsKeywordResult).ToList())
+        {
+            if (!string.IsNullOrWhiteSpace(item.SongId))
+            {
+                _saveMap.Remove(item.SongId);
+                _songLinkMap.Remove(item.SongId);
+            }
+
+            Items.Remove(item);
+        }
+    }
+
+    private static int ScoreFetchedCandidate(
+        BatchSongCandidate candidate,
+        SaveVo saveVo,
+        string? preferredArtist)
+    {
+        var score = string.IsNullOrWhiteSpace(saveVo.LyricVo.Lyric) ? 0 : 100;
+        if (!string.IsNullOrWhiteSpace(saveVo.LyricVo.TranslateLyric))
+        {
+            score += 50;
+        }
+
+        if (!string.IsNullOrWhiteSpace(saveVo.LyricVo.TransliterationLyric))
+        {
+            score += 5;
+        }
+
+        if (BatchSongMatcher.ArtistMatches(candidate.Artists, preferredArtist))
+        {
+            score += 20;
+        }
+
+        if (candidate.Source == SearchSourceEnum.NET_EASE_MUSIC)
+        {
+            score += 1;
+        }
+
+        return score;
     }
 
     private void RefreshStats()

--- a/cross-platform/MusicLyricApp/ViewModels/MainWindowViewModel.cs
+++ b/cross-platform/MusicLyricApp/ViewModels/MainWindowViewModel.cs
@@ -34,7 +34,7 @@ public partial class MainWindowViewModel : ViewModelBase
     
     public SignalLampViewModel LampVm { get; } = new();
 
-    [ObservableProperty] private string _appTitle = "MusicLyricApp v7.3";
+    [ObservableProperty] private string _appTitle = "MusicLyricApp v7.3 Batch";
 
     [ObservableProperty] private string _lastSaveFolderPath = "";
     [ObservableProperty] private string _tipTimestamp = "";

--- a/cross-platform/MusicLyricApp/Views/BatchSearchView.axaml
+++ b/cross-platform/MusicLyricApp/Views/BatchSearchView.axaml
@@ -16,20 +16,35 @@
         </Style>
     </UserControl.Styles>
 
-    <Grid RowDefinitions="Auto,*,Auto,Auto" Margin="12" RowSpacing="10">
+    <Grid RowDefinitions="Auto,Auto,*,Auto,Auto" Margin="12" RowSpacing="10">
         <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="8">
             <TextBox Text="{Binding BatchInputText}"
-                     Height="60"
+                     Height="96"
                      AcceptsReturn="True"
                      TextWrapping="Wrap"
-                     IsReadOnly="True" />
-            <Button Grid.Column="1"
-                    Content="本地扫描"
-                    Width="130"
-                    Command="{Binding ExecuteSelectFolderCommand}" />
+                     Watermark="每行一个歌名；也可直接粘贴含网易云链接的 Markdown 文件" />
+            <StackPanel Grid.Column="1" Spacing="8">
+                <Button Content="按歌名/链接批量搜索"
+                        Width="150"
+                        Command="{Binding ExecuteSearchNamesCommand}" />
+                <Button Content="本地扫描"
+                        Width="150"
+                        Command="{Binding ExecuteSelectFolderCommand}" />
+            </StackPanel>
         </Grid>
 
-        <DataGrid Grid.Row="1"
+        <Grid Grid.Row="1" ColumnDefinitions="Auto,220,*" ColumnSpacing="8">
+            <TextBlock Text="优先歌手" VerticalAlignment="Center" />
+            <TextBox Grid.Column="1"
+                     Text="{Binding PreferredArtist}"
+                     Watermark="可留空" />
+            <TextBlock Grid.Column="2"
+                       Text="{Binding SearchProgressText}"
+                       Foreground="#667085"
+                       VerticalAlignment="Center" />
+        </Grid>
+
+        <DataGrid Grid.Row="2"
                   ItemsSource="{Binding Items}"
                   AutoGenerateColumns="False"
                   CanUserReorderColumns="False"
@@ -58,11 +73,13 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
+                <DataGridTextColumn Header="输入歌名" Binding="{Binding RequestedName}" Width="160" />
                 <DataGridTextColumn Header="歌曲源" Binding="{Binding SongSource}" Width="90" />
                 <DataGridTextColumn Header="歌曲ID" Binding="{Binding SongId}" Width="120" />
                 <DataGridTextColumn Header="歌曲名" Binding="{Binding SongName}" Width="*" />
                 <DataGridTextColumn Header="歌手" Binding="{Binding Singer}" Width="180" />
                 <DataGridTextColumn Header="专辑" Binding="{Binding Album}" Width="200" />
+                <DataGridTextColumn Header="译文" Binding="{Binding TranslationStatus}" Width="70" />
                 <DataGridTemplateColumn Header="状态" Width="120" CanUserSort="False">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
@@ -84,14 +101,14 @@
             </DataGrid.Columns>
         </DataGrid>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
             <Button Content="全选" Width="110" Command="{Binding ExecuteSelectAllCommand}" />
             <Button Content="取消全选" Width="130" Command="{Binding ExecuteClearSelectedCommand}" />
             <Button Content="保存选中" Width="130" Command="{Binding ExecuteSaveSelectedCommand}" />
             <Button Content="删除选中" Width="130" Command="{Binding ExecuteDeleteSelectedCommand}" />
         </StackPanel>
 
-        <Border Grid.Row="3" Padding="8" BorderBrush="#D0D7DE" BorderThickness="1" CornerRadius="6" Background="#FAFBFC">
+        <Border Grid.Row="4" Padding="8" BorderBrush="#D0D7DE" BorderThickness="1" CornerRadius="6" Background="#FAFBFC">
             <TextBlock TextTrimming="CharacterEllipsis">
                 <Run Text="【提示】 " Foreground="#344054" />
                 <Run Text="[" Foreground="#98A2B3" />

--- a/docs/plans/2026-07-20-batch-song-name-search-design.md
+++ b/docs/plans/2026-07-20-batch-song-name-search-design.md
@@ -1,0 +1,28 @@
+# Batch song-name search design
+
+## Goal
+
+Extend the existing download manager so users can paste one song name per line and resolve multiple songs without first collecting provider-specific IDs. The existing ID, link, album, playlist, folder scan, lyric rendering, and save flows remain unchanged.
+
+## User flow
+
+The download manager input becomes editable. A user pastes song titles, optionally using `title | artist`, and clicks **按歌名批量搜索**. The app searches NetEase Cloud Music and QQ Music for every title, keeps only normalized exact-title matches, and prefers the requested artist. If no artist is supplied, the optional preferred-artist field is used as a ranking hint rather than a hard filter.
+
+For each query, the app retrieves the best exact match from both providers when available. It prefers a successful result containing original lyrics and an existing translation, then an artist match, then NetEase as a stable tie-breaker. A matched item is selected automatically and appears in the existing download manager table. Missing or non-exact results are displayed as unresolved rows and are never silently substituted with a fuzzy title.
+
+The existing **保存选中** command performs the actual save using the user's current lyric format and output settings. The new feature does not change translation-provider credentials or invent missing translations.
+
+## Components
+
+- `BatchSongMatcher`: pure parsing, normalization, exact-title filtering, and deterministic ranking. It accepts plain lines, Markdown table rows, and `title | artist` input.
+- `BatchSearchViewModel`: orchestrates provider searches, lyric retrieval, translation-aware provider selection, progress, cancellation-safe UI state, and result insertion.
+- `BatchSearchItemViewModel`: exposes requested title and translation availability.
+- `BatchSearchView`: adds editable multiline input, preferred artist, a batch-search button, and result columns.
+
+## Error handling
+
+Each query is isolated. A network error or missing title creates a visible unresolved row while later queries continue. Duplicate input lines are removed. Starting another run clears only the batch-name results created by the current manager session, while existing cached lyric data remains reusable.
+
+## Verification
+
+Unit tests cover input parsing, Unicode/punctuation normalization, exact-title enforcement, artist preference, and deterministic source ranking. The full solution must build for `net9.0`; tests must pass. A macOS arm64 app bundle is then produced and inspected through the running UI before the branch is pushed.


### PR DESCRIPTION
## What changed

- add editable batch input for one title per line, `title | artist`, Markdown tables, and live-set prefixes such as `M5` / `EN1`
- recognize NetEase song links in pasted Markdown and validate the returned title/artist before allowing save
- prefer NetEase candidates with platform translations
- fall back to public NetEase search and song-detail endpoints when the primary endpoints require login or omit a song
- replace old batch results on every new search so stale rows are not mixed into the next run
- keep unmatched entries visible and unselected to prevent wrong-song downloads
- move macOS logs outside the app bundle so runtime logs do not invalidate code signing

## Validation

- `dotnet test MusicLyricApp.sln --configuration Release`: 73 passed, 0 failed
- authoritative DAY2 setlist: 19/19 Markdown rows parsed with direct NetEase IDs
- corrected-link live smoke test: 4/4 song details matched MyGO!!!!! and contained NetEase translations
- macOS arm64 app built, ad-hoc signed, installed, launched, and verified

## Notes

This remains a draft because the UI copy is currently Chinese-first and the fallback search uses undocumented public endpoints.